### PR TITLE
Make activities blocking

### DIFF
--- a/pdchaosazure/__init__.py
+++ b/pdchaosazure/__init__.py
@@ -33,32 +33,25 @@ def discover(discover_system: bool = True) -> Discovery:
     return discovery
 
 
-def init_client(
-        experiment_secrets: Secrets,
-        experiment_configuration: Configuration) -> ComputeManagementClient:
-
+def init_client(experiment_secrets: Secrets, experiment_configuration: Configuration) -> ComputeManagementClient:
     secrets = load_secrets(experiment_secrets)
     configuration = load_subscription_id(experiment_configuration)
+
     with auth(secrets) as authentication:
         base_url = secrets.get('cloud').endpoints.resource_manager
-        client = ComputeManagementClient(
-            credentials=authentication,
-            subscription_id=configuration.get('subscription_id'),
-            base_url=base_url)
+        client = ComputeManagementClient(credentials=authentication,
+                                         subscription_id=configuration.get('subscription_id'),
+                                         base_url=base_url)
 
         return client
 
 
-def init_resource_graph_client(
-        experiment_secrets: Secrets) -> ResourceGraphClient:
-
+def init_resource_graph_client(experiment_secrets: Secrets) -> ResourceGraphClient:
     secrets = load_secrets(experiment_secrets)
+
     with auth(secrets) as authentication:
         base_url = secrets.get('cloud').endpoints.resource_manager
-        client = ResourceGraphClient(
-            credentials=authentication,
-            base_url=base_url)
-
+        client = ResourceGraphClient(credentials=authentication, base_url=base_url)
         return client
 
 

--- a/pdchaosazure/__init__.py
+++ b/pdchaosazure/__init__.py
@@ -13,7 +13,7 @@ from chaoslib.types import (Configuration, DiscoveredActivities, Discovery,
 from logzero import logger
 
 from pdchaosazure.auth import auth
-from pdchaosazure.common.config import load_configuration, load_secrets
+from pdchaosazure.common.config import load_subscription_id, load_secrets
 
 __all__ = [
     "__version__", "discover", "init_client", "init_resource_graph_client"
@@ -38,7 +38,7 @@ def init_client(
         experiment_configuration: Configuration) -> ComputeManagementClient:
 
     secrets = load_secrets(experiment_secrets)
-    configuration = load_configuration(experiment_configuration)
+    configuration = load_subscription_id(experiment_configuration)
     with auth(secrets) as authentication:
         base_url = secrets.get('cloud').endpoints.resource_manager
         client = ComputeManagementClient(

--- a/pdchaosazure/common/config.py
+++ b/pdchaosazure/common/config.py
@@ -1,4 +1,3 @@
-
 import io
 import json
 import os
@@ -101,20 +100,31 @@ def load_secrets(experiment_secrets: Secrets):
     return {}
 
 
-def load_configuration(experiment_configuration: Configuration):
+def load_timeout(experiment_configuration: Configuration) -> int:
+    """ Defaults to 600 seconds if no timeout is given. """
+    result = 600
+
+    if experiment_configuration:
+        result = experiment_configuration.get("timeout", result)
+
+    return result
+
+
+def load_subscription_id(experiment_configuration: Configuration):
     subscription_id = None
-    # 1: lookup for configuration in experiment config file
+
+    # 1: lookup in experiment definition
     if experiment_configuration:
         subscription_id = experiment_configuration.get("azure_subscription_id")
         # check legacy subscription location
         if not subscription_id:
-            subscription_id = experiment_configuration\
+            subscription_id = experiment_configuration \
                 .get('azure', {}).get('subscription_id')
 
     if subscription_id:
         return {'subscription_id': subscription_id}
 
-    # 2: lookup for configuration in azure auth file
+    # 2: lookup in Azure auth file
     az_auth_file = _load_azure_auth_file()
     if az_auth_file:
         return {'subscription_id': az_auth_file.get('subscriptionId')}

--- a/pdchaosazure/common/resources/query.py
+++ b/pdchaosazure/common/resources/query.py
@@ -1,14 +1,14 @@
 from azure.mgmt.resourcegraph.models import QueryRequest
 from chaoslib import Configuration
 
-from pdchaosazure.common.config import load_configuration
+from pdchaosazure.common.config import load_subscription_id
 
 
 def create_request(
         resource_type: str, user_query: str, experiment_configuration: Configuration) -> QueryRequest:
 
     prepared_query = __prepare(resource_type, user_query)
-    configuration = load_configuration(experiment_configuration)
+    configuration = load_subscription_id(experiment_configuration)
 
     result = QueryRequest(
         query=prepared_query,

--- a/pdchaosazure/machine/probes.py
+++ b/pdchaosazure/machine/probes.py
@@ -23,11 +23,10 @@ def describe_machines(filter: str = None,
         'where resourceGroup=="myresourcegroup" and name="myresourcename"'
     """
     logger.debug(
-        "Start describe_machines: configuration='{}', filter='{}'".format(
-            configuration, filter))
+        "Starting {}: configuration='{}', filter='{}'".format(describe_machines.__name__, configuration, filter))
 
-    machines = fetch_resources(filter, RES_TYPE_VM, secrets, configuration)
-    return machines
+    result = fetch_resources(filter, RES_TYPE_VM, secrets, configuration)
+    return result
 
 
 def count_machines(filter: str = None,
@@ -45,8 +44,7 @@ def count_machines(filter: str = None,
         'where resourceGroup=="myresourcegroup" and name="myresourcename"'
     """
     logger.debug(
-        "Start count_machines: configuration='{}', filter='{}'".format(
-            configuration, filter))
+        "Starting {}: configuration='{}', filter='{}'".format(count_machines.__name__, configuration, filter))
 
-    machines = fetch_resources(filter, RES_TYPE_VM, secrets, configuration)
-    return len(machines)
+    result = fetch_resources(filter, RES_TYPE_VM, secrets, configuration)
+    return len(result)

--- a/pdchaosazure/vmss/actions.py
+++ b/pdchaosazure/vmss/actions.py
@@ -42,7 +42,7 @@ def delete_instance(filter: str = None,
     client = init_client(secrets, configuration)
     vmss_list = fetch_vmss(filter, configuration, secrets)
     vmss_records = Records()
-    
+
     for vmss in vmss_list:
         instances_records = Records()
         instances = fetch_instances(vmss, instance_criteria, configuration, secrets)
@@ -87,7 +87,7 @@ def restart_instance(filter: str = None,
     client = init_client(secrets, configuration)
     vmss_list = fetch_vmss(filter, configuration, secrets)
     vmss_records = Records()
-    
+
     for vmss in vmss_list:
         instances_records = Records()
         instances = fetch_instances(vmss, instance_criteria, configuration, secrets)

--- a/pdchaosazure/vmss/fetcher.py
+++ b/pdchaosazure/vmss/fetcher.py
@@ -2,45 +2,34 @@ import random
 from typing import Any, Dict, Iterable, Mapping, List
 
 from azure.mgmt.compute import ComputeManagementClient
-from chaoslib import Configuration, Secrets
 from chaoslib.exceptions import FailedActivity
 from logzero import logger
 
-from pdchaosazure import load_secrets, load_subscription_id, auth
 from pdchaosazure.common.resources.graph import fetch_resources
 from pdchaosazure.vmss.constants import RES_TYPE_VMSS
 
 
-def fetch_instances(scale_set, instance_criteria,
-                    configuration, secrets) -> List[Dict[str, Any]]:
+def fetch_instances(scale_set, instance_criteria, client: ComputeManagementClient) -> List[Dict[str, Any]]:
     if not instance_criteria:
-        instance = __random_instance_from(
-            scale_set, configuration, secrets)
+        instance = __random_instance_from(scale_set, client)
         result = [instance]
 
     else:
-        result = instances_by_criteria(
-            scale_set, configuration, instance_criteria, secrets)
+        result = instances_by_criteria(scale_set, instance_criteria, client)
 
     return result
 
 
-def instances_by_criteria(
-        vmss_choice: dict,
-        configuration: Configuration = None,
-        instance_criteria: Iterable[Mapping[str, any]] = None,
-        secrets: Secrets = None) -> List[Dict[str, Any]]:
+def instances_by_criteria(vmss: dict, instance_criteria, client) -> List[Dict[str, Any]]:
     result = []
-    instances = fetch_all_vmss_instances(vmss_choice, configuration, secrets)
+    instances = fetch_all_vmss_instances(vmss, client)
 
     for instance in instances:
         if __is_criteria_matched(instance, instance_criteria):
             result.append(instance)
 
     if len(result) == 0:
-        raise FailedActivity(
-            "No VMSS instance found for criteria '{}'".format(
-                instance_criteria))
+        raise FailedActivity("No VMSS instance found for criteria '{}'".format(instance_criteria))
 
     return result
 
@@ -51,27 +40,12 @@ def fetch_vmss(filter, configuration, secrets) -> List[dict]:
     if not vmss:
         raise FailedActivity("No VMSS found")
 
-    else:
-        logger.debug(
-            "Fetched VMSS: {}".format([set['name'] for set in vmss]))
-
     return vmss
 
 
-def fetch_all_vmss_instances(choice, configuration, secrets) -> List[Dict]:
+def fetch_all_vmss_instances(vmss, client: ComputeManagementClient) -> List[Dict]:
     vmss_instances = []
-    secrets1 = load_secrets(secrets)
-    configuration1 = load_subscription_id(configuration)
-    with auth(secrets1) as authentication:
-        base_url = secrets1.get('cloud').endpoints.resource_manager
-        client1 = ComputeManagementClient(
-            credentials=authentication,
-            subscription_id=configuration1.get('subscription_id'),
-            base_url=base_url)
-
-        client = client1
-    pages = client.virtual_machine_scale_set_vms.list(
-        choice['resourceGroup'], choice['name'])
+    pages = client.virtual_machine_scale_set_vms.list(vmss['resourceGroup'], vmss['name'])
     first_page = pages.advance_page()
     vmss_instances.extend(list(first_page))
 
@@ -82,31 +56,24 @@ def fetch_all_vmss_instances(choice, configuration, secrets) -> List[Dict]:
         except StopIteration:
             break
 
-    results = __parse_vmss_instances_result(vmss_instances, choice)
+    results = __parse_vmss_instances_result(vmss_instances, vmss)
     return results
 
 
 #############################################################################
 # Private helper functions
 #############################################################################
-def __random_instance_from(
-        scale_set,
-        configuration,
-        secrets) -> Dict[str, Any]:
-    instances = fetch_all_vmss_instances(
-        scale_set, configuration, secrets)
+def __random_instance_from(scale_set, client) -> Dict[str, Any]:
+    instances = fetch_all_vmss_instances(scale_set, client)
     if not instances:
         raise FailedActivity("No VMSS instances found")
     else:
-        logger.debug(
-            "Found VMSS instances: {}".format(
-                [x['name'] for x in instances]))
+        logger.debug("Found VMSS instances: {}".format([x['name'] for x in instances]))
 
     return random.choice(instances)
 
 
-def __is_criteria_matched(instance: dict,
-                          criteria: Iterable[Mapping[str, any]] = None):
+def __is_criteria_matched(instance: dict, criteria: Iterable[Mapping[str, any]] = None):
     for criterion in criteria:
         mismatch = False
 

--- a/pdchaosazure/vmss/fetcher.py
+++ b/pdchaosazure/vmss/fetcher.py
@@ -30,7 +30,7 @@ def instances_by_criteria(
         instance_criteria: Iterable[Mapping[str, any]] = None,
         secrets: Secrets = None) -> List[Dict[str, Any]]:
     result = []
-    instances = __fetch_vmss_instances(vmss_choice, configuration, secrets)
+    instances = fetch_all_vmss_instances(vmss_choice, configuration, secrets)
 
     for instance in instances:
         if __is_criteria_matched(instance, instance_criteria):
@@ -57,10 +57,7 @@ def fetch_vmss(filter, configuration, secrets) -> List[dict]:
     return vmss
 
 
-#############################################################################
-# Private helper functions
-#############################################################################
-def __fetch_vmss_instances(choice, configuration, secrets) -> List[Dict]:
+def fetch_all_vmss_instances(choice, configuration, secrets) -> List[Dict]:
     vmss_instances = []
     client = init_client(secrets, configuration)
     pages = client.virtual_machine_scale_set_vms.list(
@@ -79,11 +76,14 @@ def __fetch_vmss_instances(choice, configuration, secrets) -> List[Dict]:
     return results
 
 
+#############################################################################
+# Private helper functions
+#############################################################################
 def __random_instance_from(
         scale_set,
         configuration,
         secrets) -> Dict[str, Any]:
-    instances = __fetch_vmss_instances(
+    instances = fetch_all_vmss_instances(
         scale_set, configuration, secrets)
     if not instances:
         raise FailedActivity("No VMSS instances found")

--- a/pdchaosazure/vmss/probes.py
+++ b/pdchaosazure/vmss/probes.py
@@ -2,10 +2,9 @@
 from chaoslib.types import Configuration, Secrets
 from logzero import logger
 
-from pdchaosazure.common.resources.graph import fetch_resources
-from pdchaosazure.vmss.constants import RES_TYPE_VMSS
-
 __all__ = ["count_instances"]
+
+from pdchaosazure.vmss.fetcher import fetch_vmss, fetch_all_vmss_instances
 
 
 def count_instances(filter: str = None,
@@ -23,8 +22,12 @@ def count_instances(filter: str = None,
         'where resourceGroup=="myresourcegroup" and name="myresourcename"'
     """
     logger.debug(
-        "Starting count_instances: configuration='{}', filter='{}'".format(
-            configuration, filter))
+        "Starting {}: configuration='{}', filter='{}'".format(count_instances.__name__, configuration, filter))
 
-    instances = fetch_resources(filter, RES_TYPE_VMSS, secrets, configuration)
-    return len(instances)
+    result = []
+    vmss = fetch_vmss(filter, configuration, secrets)
+    for set in vmss:
+        instances = fetch_all_vmss_instances(set, configuration, secrets)
+        result.extend(instances)
+
+    return len(result)

--- a/pdchaosazure/vmss/probes.py
+++ b/pdchaosazure/vmss/probes.py
@@ -4,6 +4,7 @@ from logzero import logger
 
 __all__ = ["count_instances"]
 
+from pdchaosazure import init_client
 from pdchaosazure.vmss.fetcher import fetch_vmss, fetch_all_vmss_instances
 
 
@@ -25,9 +26,10 @@ def count_instances(filter: str = None,
         "Starting {}: configuration='{}', filter='{}'".format(count_instances.__name__, configuration, filter))
 
     result = []
+    client = init_client(secrets, configuration)
     vmss_list = fetch_vmss(filter, configuration, secrets)
     for vmss in vmss_list:
-        instances = fetch_all_vmss_instances(vmss, configuration, secrets)
+        instances = fetch_all_vmss_instances(vmss, client)
         result.extend(instances)
 
     return len(result)

--- a/pdchaosazure/vmss/probes.py
+++ b/pdchaosazure/vmss/probes.py
@@ -25,9 +25,9 @@ def count_instances(filter: str = None,
         "Starting {}: configuration='{}', filter='{}'".format(count_instances.__name__, configuration, filter))
 
     result = []
-    vmss = fetch_vmss(filter, configuration, secrets)
-    for set in vmss:
-        instances = fetch_all_vmss_instances(set, configuration, secrets)
+    vmss_list = fetch_vmss(filter, configuration, secrets)
+    for vmss in vmss_list:
+        instances = fetch_all_vmss_instances(vmss, configuration, secrets)
         result.extend(instances)
 
     return len(result)

--- a/pdchaosazure/webapp/actions.py
+++ b/pdchaosazure/webapp/actions.py
@@ -31,10 +31,10 @@ def stop_webapp(filter: str = None,
     client = init_client(secrets, configuration)
     webapps = __fetch_webapps(filter, configuration, secrets)
     webapps_records = Records()
-    
+
     for webapp in webapps:
         logger.debug("Stopping web app: {}".format(webapp['name']))
-        
+
         try:
             poller = client.web_apps.stop(webapp['resourceGroup'], webapp['name'])
 

--- a/pdchaosazure/webapp/actions.py
+++ b/pdchaosazure/webapp/actions.py
@@ -1,15 +1,14 @@
-import random
-
 from chaoslib import Secrets, Configuration
 from chaoslib.exceptions import FailedActivity
 from logzero import logger
 
 from pdchaosazure import init_client
+from pdchaosazure.common import cleanse, config
 from pdchaosazure.common.resources.graph import fetch_resources
+from pdchaosazure.vmss.records import Records
 from pdchaosazure.webapp.constants import RES_TYPE_WEBAPP
 
-
-__all__ = ["stop_webapp", "restart_webapp", "start_webapp", "delete_webapp"]
+__all__ = ["stop_webapp", "restart_webapp", "delete_webapp"]
 
 
 def stop_webapp(filter: str = None,
@@ -26,15 +25,18 @@ def stop_webapp(filter: str = None,
         Filtering example:
         'where resourceGroup=="myresourcegroup" and name="myresourcename"'
     """
-    logger.debug(
-        "Start stop_webapp: configuration='{}', filter='{}'".format(
-            configuration, filter))
+    logger.debug("Starting {}: configuration='{}', filter='{}'".format(stop_webapp.__name__, configuration, filter))
 
-    choice = __fetch_webapp_at_random(filter, configuration, secrets)
+    webapps = __fetch_webapps(filter, configuration, secrets)
+    compute_client = init_client(secrets, configuration)
+    webapps_records = Records()
+    for webapp in webapps:
+        logger.debug("Stopping web app: {}".format(webapp['name']))
+        poller = compute_client.web_apps.stop(webapp['resourceGroup'], webapp['name'])
+        poller.result(config.load_timeout(configuration))
+        webapps_records.add(cleanse.machine(webapp))
 
-    logger.debug("Stopping web app: {}".format(choice['name']))
-    client = init_client(secrets, configuration)
-    client.web_apps.stop(choice['resourceGroup'], choice['name'])
+    return webapps_records.output_as_dict('resources')
 
 
 def restart_webapp(filter: str = None,
@@ -51,40 +53,18 @@ def restart_webapp(filter: str = None,
         Filtering example:
         'where resourceGroup=="myresourcegroup" and name="myresourcename"'
     """
-    logger.debug(
-        "Start restart_webapp: configuration='{}', filter='{}'".format(
-            configuration, filter))
+    logger.debug("Starting {}: configuration='{}', filter='{}'".format(restart_webapp.__name__, configuration, filter))
 
-    choice = __fetch_webapp_at_random(filter, configuration, secrets)
+    webapps = __fetch_webapps(filter, configuration, secrets)
+    compute_client = init_client(secrets, configuration)
+    webapps_records = Records()
+    for webapp in webapps:
+        logger.debug("Restarting web app: {}".format(webapp['name']))
+        poller = compute_client.web_apps.restart(webapp['resourceGroup'], webapp['name'])
+        poller.result(config.load_timeout(configuration))
+        webapps_records.add(cleanse.machine(webapp))
 
-    logger.debug("Restarting web app: {}".format(choice['name']))
-    client = init_client(secrets, configuration)
-    client.web_apps.restart(choice['resourceGroup'], choice['name'])
-
-
-def start_webapp(filter: str = None,
-                 configuration: Configuration = None,
-                 secrets: Secrets = None):
-    """
-    Start a web app at random.
-
-    Parameters
-    ----------
-    filter : str
-        Filter the web apps. If the filter is omitted all web apps in
-        the subscription will be selected as potential chaos candidates.
-        Filtering example:
-        'where resourceGroup=="myresourcegroup" and name="myresourcename"'
-    """
-    logger.debug(
-        "Start start_webapp: configuration='{}', filter='{}'".format(
-            configuration, filter))
-
-    choice = __fetch_webapp_at_random(filter, configuration, secrets)
-
-    logger.debug("Starting web app: {}".format(choice['name']))
-    client = init_client(secrets, configuration)
-    client.web_apps.start(choice['resourceGroup'], choice['name'])
+    return webapps_records.output_as_dict('resources')
 
 
 def delete_webapp(filter: str = None,
@@ -104,33 +84,26 @@ def delete_webapp(filter: str = None,
         Filtering example:
         'where resourceGroup=="myresourcegroup" and name="myresourcename"'
     """
-    logger.debug(
-        "Start delete_webapp: configuration='{}', filter='{}'".format(
-            configuration, filter))
+    logger.debug("Starting {}: configuration='{}', filter='{}'".format(delete_webapp.__name__, configuration, filter))
 
-    choice = __fetch_webapp_at_random(filter, configuration, secrets)
+    webapps = __fetch_webapps(filter, configuration, secrets)
+    compute_client = init_client(secrets, configuration)
+    webapps_records = Records()
+    for webapp in webapps:
+        logger.debug("Deleting web app: {}".format(webapp['name']))
+        poller = compute_client.web_apps.delete(webapp['resourceGroup'], webapp['name'])
+        poller.result(config.load_timeout(configuration))
+        webapps_records.add(cleanse.machine(webapp))
 
-    logger.debug("Deleting web app: {}".format(choice['name']))
-    client = init_client(secrets, configuration)
-    client.web_apps.delete(choice['resourceGroup'], choice['name'])
-
-
-def fetch_webapps(filter, configuration, secrets):
-    webapps = fetch_resources(filter, RES_TYPE_WEBAPP, secrets, configuration)
-    if not webapps:
-        logger.warning("No web apps found")
-        raise FailedActivity("No web apps found")
-    else:
-        logger.debug(
-            "Fetched web apps: {}".format(
-                [x['name'] for x in webapps]))
-    return webapps
+    return webapps_records.output_as_dict('resources')
 
 
 ###############################################################################
 # Private helper functions
 ###############################################################################
-def __fetch_webapp_at_random(filter, configuration, secrets):
-    webapps = fetch_webapps(filter, configuration, secrets)
-    choice = random.choice(webapps)
-    return choice
+def __fetch_webapps(filter, configuration, secrets):
+    result = fetch_resources(filter, RES_TYPE_WEBAPP, secrets, configuration)
+    if not result:
+        logger.warning("No web apps found")
+        raise FailedActivity("No web apps found")
+    return result

--- a/pdchaosazure/webapp/probes.py
+++ b/pdchaosazure/webapp/probes.py
@@ -20,11 +20,9 @@ def describe_webapps(filter: str = None,
         'where resourceGroup=="myresourcegroup" and name="myresourcename"'
     """
     logger.debug(
-        "Start describe_webapps: configuration='{}', filter='{}'".format(
-            configuration, filter))
+        "Starting {}: configuration='{}', filter='{}'".format(describe_webapps.__name__, configuration, filter))
 
-    webapps = fetch_resources(filter, RES_TYPE_WEBAPP, secrets, configuration)
-    return webapps
+    return fetch_resources(filter, RES_TYPE_WEBAPP, secrets, configuration)
 
 
 def count_webapps(filter: str = None,
@@ -41,9 +39,7 @@ def count_webapps(filter: str = None,
         Filtering example:
         'where resourceGroup=="myresourcegroup" and name="myresourcename"'
     """
-    logger.debug(
-        "Start count_machines: configuration='{}', filter='{}'".format(
-            configuration, filter))
+    logger.debug("Start {}: configuration='{}', filter='{}'".format(count_webapps.__name__, configuration, filter))
 
     webapps = fetch_resources(filter, RES_TYPE_WEBAPP, secrets, configuration)
     return len(webapps)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 norecursedirs=dist build htmlcov docs .eggs
-addopts=-v -rxs --junitxml=tests/.results/junit-test-results.xml --cov=pdchaosazure --cov-report term-missing:skip-covered --cov-report xml:tests/.results/coverage.xml tests/
+addopts=-v -rxs
+#--junitxml=tests/.results/junit-test-results.xml --cov=pdchaosazure --cov-report term-missing:skip-covered --cov-report xml:tests/.results/coverage.xml tests/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 norecursedirs=dist build htmlcov docs .eggs
-addopts=-v -rxs
-#--junitxml=tests/.results/junit-test-results.xml --cov=pdchaosazure --cov-report term-missing:skip-covered --cov-report xml:tests/.results/coverage.xml tests/
+addopts=-v -rxs --junitxml=tests/.results/junit-test-results.xml --cov=pdchaosazure --cov-report term-missing:skip-covered --cov-report xml:tests/.results/coverage.xml tests/

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -65,7 +65,7 @@ def test_load_subscription_from_experiment_dict():
     }
 
     # act
-    configuration = config.load_configuration(experiment_configuration)
+    configuration = config.load_subscription_id(experiment_configuration)
 
     # assert
     assert configuration.get('subscription_id') == "AZURE_SUBSCRIPTION_ID"
@@ -80,7 +80,7 @@ def test_load_legacy_subscription_from_experiment_dict():
     }
 
     # act
-    configuration = config.load_configuration(experiment_configuration)
+    configuration = config.load_subscription_id(experiment_configuration)
 
     # assert
     assert configuration.get('subscription_id') == "AZURE_SUBSCRIPTION_ID"
@@ -94,7 +94,7 @@ def test_load_subscription_from_credential_file(monkeypatch):
         os.path.join(settings_dir, 'credentials.json'))
 
     # act
-    configuration = config.load_configuration(experiment_configuration)
+    configuration = config.load_subscription_id(experiment_configuration)
 
     # assert
     assert configuration.get('subscription_id') == "AZURE_SUBSCRIPTION_ID"

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -98,3 +98,30 @@ def test_load_subscription_from_credential_file(monkeypatch):
 
     # assert
     assert configuration.get('subscription_id') == "AZURE_SUBSCRIPTION_ID"
+
+
+def test_load_timeout_from_experiment_dict():
+    # arrange
+    experiment_configuration = {
+        "azure_subscription_id": "AZURE_SUBSCRIPTION_ID",
+        "timeout": 500
+    }
+
+    # act
+    timeout = config.load_timeout(experiment_configuration)
+
+    # assert
+    assert timeout == 500
+
+
+def test_load_timeout_from_experiment_dict():
+    # arrange
+    experiment_configuration = {
+        "azure_subscription_id": "AZURE_SUBSCRIPTION_ID",
+    }
+
+    # act
+    timeout = config.load_timeout(experiment_configuration)
+
+    # assert
+    assert timeout == 600

--- a/tests/machine/test_machine_actions.py
+++ b/tests/machine/test_machine_actions.py
@@ -221,15 +221,13 @@ def test_stress_cpu(mocked_command_run, mocked_command_prepare, fetch):
     secrets = secrets_provider.provide_secrets_via_service_principal()
 
     # act
-    stress_cpu(filter="where name=='some_linux_machine'",
-               duration=60, timeout=60, configuration=config, secrets=secrets)
+    stress_cpu(filter="where name=='some_linux_machine'", duration=60, configuration=config, secrets=secrets)
 
     # assert
-    fetch.assert_called_with(
-        "where name=='some_linux_machine'", RES_TYPE_VM, secrets, config)
+    fetch.assert_called_with("where name=='some_linux_machine'", RES_TYPE_VM, secrets, config)
     mocked_command_prepare.assert_called_with(machine, 'cpu_stress_test')
     mocked_command_run.assert_called_with(
-        machine['resourceGroup'], machine, 120,
+        machine['resourceGroup'], machine, 60,
         {
             'command_id': 'RunShellScript',
             'script': ['cpu_stress_test.sh'],
@@ -246,7 +244,7 @@ def test_stress_cpu(mocked_command_run, mocked_command_prepare, fetch):
 @patch.object(pdchaosazure.common.compute.command, 'prepare_path', autospec=True)
 @patch.object(pdchaosazure.common.compute.command, 'run', autospec=True)
 def test_fill_disk(mocked_command_run, mocked_command_prepare_path,
-                         mocked_command_prepare, fetch):
+                   mocked_command_prepare, fetch):
     # arrange mocks
     mocked_command_prepare.return_value = 'RunShellScript', 'fill_disk.sh'
     mocked_command_prepare_path.return_value = '/root/burn/hard'
@@ -259,16 +257,14 @@ def test_fill_disk(mocked_command_run, mocked_command_prepare_path,
     secrets = secrets_provider.provide_secrets_via_service_principal()
 
     # act
-    fill_disk(filter="where name=='some_linux_machine'",
-              duration=60, timeout=60, size=1000,
-              path='/root/burn/hard', configuration=config, secrets=secrets)
+    fill_disk(filter="where name=='some_linux_machine'", duration=60, size=1000, path='/root/burn/hard',
+              configuration=config, secrets=secrets)
 
     # assert
-    fetch.assert_called_with(
-        "where name=='some_linux_machine'", RES_TYPE_VM, secrets, config)
+    fetch.assert_called_with("where name=='some_linux_machine'", RES_TYPE_VM, secrets, config)
     mocked_command_prepare.assert_called_with(machine, 'fill_disk')
     mocked_command_run.assert_called_with(
-        machine['resourceGroup'], machine, 120,
+        machine['resourceGroup'], machine, 60,
         {
             'command_id': 'RunShellScript',
             'script': ['fill_disk.sh'],
@@ -297,16 +293,14 @@ def test_network_latency(mocked_command_run, mocked_command_prepare, fetch):
     secrets = secrets_provider.provide_secrets_via_service_principal()
 
     # act
-    network_latency(filter="where name=='some_linux_machine'",
-                    duration=60, delay=200, jitter=50, timeout=60,
-                    configuration=config, secrets=secrets)
+    network_latency(filter="where name=='some_linux_machine'", duration=60, delay=200, jitter=50, configuration=config,
+                    secrets=secrets)
 
     # assert
-    fetch.assert_called_with(
-        "where name=='some_linux_machine'", RES_TYPE_VM, secrets, config)
+    fetch.assert_called_with("where name=='some_linux_machine'", RES_TYPE_VM, secrets, config)
     mocked_command_prepare.assert_called_with(machine, 'network_latency')
     mocked_command_run.assert_called_with(
-        machine['resourceGroup'], machine, 120,
+        machine['resourceGroup'], machine, 60,
         {
             'command_id': 'RunShellScript',
             'script': ['network_latency.sh'],
@@ -335,15 +329,14 @@ def test_burn_io(mocked_command_run, mocked_command_prepare, fetch):
     secrets = secrets_provider.provide_secrets_via_service_principal()
 
     # act
-    burn_io(filter="where name=='some_linux_machine'",
-            duration=60, configuration=config, secrets=secrets)
+    burn_io(filter="where name=='some_linux_machine'", duration=60, configuration=config, secrets=secrets)
 
     # assert
     fetch.assert_called_with(
         "where name=='some_linux_machine'", RES_TYPE_VM, secrets, config)
     mocked_command_prepare.assert_called_with(machine, 'burn_io')
     mocked_command_run.assert_called_with(
-        machine['resourceGroup'], machine, 120,
+        machine['resourceGroup'], machine, 60,
         {
             'command_id': 'RunShellScript',
             'script': ['burn_io.sh'],

--- a/tests/vmss/mock_client.py
+++ b/tests/vmss/mock_client.py
@@ -1,0 +1,26 @@
+class MockLROPoller(object):
+    def result(self, timeout: None):
+        pass
+
+
+class MockVirtualMachineScaleSetVMsOperations(object):
+    def power_off(self, resource_group_name, scale_set_name, instance_id):
+        return MockLROPoller()
+
+    def delete(self, resource_group_name, scale_set_name, instance_id):
+        return MockLROPoller()
+
+    def restart(self, resource_group_name, scale_set_name, instance_id):
+        return MockLROPoller()
+
+    def deallocate(self, resource_group_name, scale_set_name, instance_id):
+        return MockLROPoller()
+
+
+class MockComputeManagementClient(object):
+    def __init__(self):
+        self.operations = MockVirtualMachineScaleSetVMsOperations()
+
+    @property
+    def virtual_machine_scale_set_vms(self):
+        return self.operations

--- a/tests/vmss/test_vmss_actions.py
+++ b/tests/vmss/test_vmss_actions.py
@@ -1,9 +1,10 @@
 from unittest.mock import patch
 
 import pdchaosazure
-from pdchaosazure.vmss.actions import delete_vmss, restart_vmss, stop_vmss, \
-    deallocate_vmss, stress_vmss_instance_cpu, network_latency, burn_io, fill_disk
+from pdchaosazure.vmss.actions import delete_instance, restart_instance, stop_instance, \
+    deallocate_instance, network_latency, burn_io, fill_disk, stress_cpu
 from tests.data import config_provider, secrets_provider, vmss_provider
+from tests.vmss.mock_client import MockComputeManagementClient
 
 
 @patch('pdchaosazure.vmss.actions.fetch_vmss', autospec=True)
@@ -20,7 +21,7 @@ def test_deallocate_vmss(client, fetch_instances, fetch_vmss):
 
     client.return_value = MockComputeManagementClient()
 
-    deallocate_vmss(None, None, None)
+    deallocate_instance(None, None, None)
 
 
 @patch('pdchaosazure.vmss.actions.fetch_vmss', autospec=True)
@@ -36,7 +37,7 @@ def test_stop_vmss(client, fetch_instances, fetch_vmss):
 
     client.return_value = MockComputeManagementClient()
 
-    stop_vmss(None, None, None, None)
+    stop_instance(None, None, None, None)
 
 
 @patch('pdchaosazure.vmss.actions.fetch_vmss', autospec=True)
@@ -52,7 +53,7 @@ def test_restart_vmss(client, fetch_instances, fetch_vmss):
 
     client.return_value = MockComputeManagementClient()
 
-    restart_vmss(None, None, None)
+    restart_instance(None, None, None)
 
 
 @patch('pdchaosazure.vmss.actions.fetch_vmss', autospec=True)
@@ -68,30 +69,7 @@ def test_delete_vmss(client, fetch_instances, fetch_vmss):
 
     client.return_value = MockComputeManagementClient()
 
-    delete_vmss(None, None, None)
-
-
-class MockVirtualMachineScaleSetVMsOperations(object):
-    def power_off(self, resource_group_name, scale_set_name, instance_id):
-        pass
-
-    def delete(self, resource_group_name, scale_set_name, instance_id):
-        pass
-
-    def restart(self, resource_group_name, scale_set_name, instance_id):
-        pass
-
-    def deallocate(self, resource_group_name, scale_set_name, instance_id):
-        pass
-
-
-class MockComputeManagementClient(object):
-    def __init__(self):
-        self.operations = MockVirtualMachineScaleSetVMsOperations()
-
-    @property
-    def virtual_machine_scale_set_vms(self):
-        return self.operations
+    delete_instance(None, None, None)
 
 
 @patch('pdchaosazure.vmss.actions.fetch_vmss', autospec=True)
@@ -113,16 +91,14 @@ def test_stress_cpu(mocked_command_run, mocked_command_prepare, fetch_instance, 
     secrets = secrets_provider.provide_secrets_via_service_principal()
 
     # act
-    stress_vmss_instance_cpu(
-        filter="where name=='some_random_instance'",
-        duration=60, timeout=60, configuration=config, secrets=secrets)
+    stress_cpu(filter="where name=='some_random_instance'", duration=60, configuration=config, secrets=secrets)
 
     # assert
     fetch_vmss.assert_called_with("where name=='some_random_instance'", config, secrets)
     fetch_instance.assert_called_with(scale_set, None, config, secrets)
     mocked_command_prepare.assert_called_with(instance, 'cpu_stress_test')
     mocked_command_run.assert_called_with(
-        scale_set['resourceGroup'], instance, 120,
+        scale_set['resourceGroup'], instance, 60,
         {
             'command_id': 'RunShellScript',
             'script': ['cpu_stress_test.sh'],
@@ -153,17 +129,15 @@ def test_network_latency(mocked_command_run, mocked_command_prepare, fetch_insta
     secrets = secrets_provider.provide_secrets_via_service_principal()
 
     # act
-    network_latency(
-        filter="where name=='some_random_instance'",
-        duration=60, timeout=60, delay=200, jitter=50,
-        configuration=config, secrets=secrets)
+    network_latency(filter="where name=='some_random_instance'", duration=60, delay=200, jitter=50,
+                    configuration=config, secrets=secrets)
 
     # assert
     fetch_vmss.assert_called_with("where name=='some_random_instance'", config, secrets)
     fetch_instances.assert_called_with(scale_set, None, config, secrets)
     mocked_command_prepare.assert_called_with(instance, 'network_latency')
     mocked_command_run.assert_called_with(
-        scale_set['resourceGroup'], instance, 120,
+        scale_set['resourceGroup'], instance, 60,
         {
             'command_id': 'RunShellScript',
             'script': ['network_latency.sh'],
@@ -196,14 +170,13 @@ def test_burn_io(mocked_command_run, mocked_command_prepare, fetch_instances, fe
     secrets = secrets_provider.provide_secrets_via_service_principal()
 
     # act
-    burn_io(filter="where name=='some_random_instance'",
-            duration=60, configuration=config, secrets=secrets)
+    burn_io(filter="where name=='some_random_instance'", duration=60, configuration=config, secrets=secrets)
 
     # assert
     fetch_vmss.assert_called_with("where name=='some_random_instance'", config, secrets)
     fetch_instances.assert_called_with(scale_set, None, config, secrets)
     mocked_command_run.assert_called_with(
-        scale_set['resourceGroup'], instance, 120,
+        scale_set['resourceGroup'], instance, 60,
         {
             'command_id': 'RunShellScript',
             'script': ['burn_io.sh'],
@@ -220,8 +193,8 @@ def test_burn_io(mocked_command_run, mocked_command_prepare, fetch_instances, fe
 @patch.object(pdchaosazure.common.compute.command, 'prepare_path', autospec=True)
 @patch.object(pdchaosazure.common.compute.command, 'prepare', autospec=True)
 @patch.object(pdchaosazure.common.compute.command, 'run', autospec=True)
-def test_fill_disk(mocked_command_run, mocked_command_prepare,
-                   mocked_command_prepare_path, fetch_instances, fetch_vmss):
+def test_fill_disk(mocked_command_run, mocked_command_prepare, mocked_command_prepare_path, fetch_instances,
+                   fetch_vmss):
     # arrange mocks
     mocked_command_prepare.return_value = 'RunShellScript', 'fill_disk.sh'
     mocked_command_prepare_path.return_value = '/root/burn/hard'
@@ -237,15 +210,14 @@ def test_fill_disk(mocked_command_run, mocked_command_prepare,
     secrets = secrets_provider.provide_secrets_via_service_principal()
 
     # act
-    fill_disk(filter="where name=='some_random_instance'",
-              duration=60, timeout=60, size=1000,
-              path='/root/burn/hard', configuration=config, secrets=secrets)
+    fill_disk(filter="where name=='some_random_instance'", duration=60, size=1000, path='/root/burn/hard',
+              configuration=config, secrets=secrets)
 
     # assert
     fetch_vmss.assert_called_with("where name=='some_random_instance'", config, secrets)
     fetch_instances.assert_called_with(scale_set, None, config, secrets)
     mocked_command_run.assert_called_with(
-        scale_set['resourceGroup'], instance, 120,
+        scale_set['resourceGroup'], instance, 60,
         {
             'command_id': 'RunShellScript',
             'script': ['fill_disk.sh'],

--- a/tests/vmss/test_vmss_actions.py
+++ b/tests/vmss/test_vmss_actions.py
@@ -74,9 +74,10 @@ def test_delete_vmss(client, fetch_instances, fetch_vmss):
 
 @patch('pdchaosazure.vmss.actions.fetch_vmss', autospec=True)
 @patch('pdchaosazure.vmss.actions.fetch_instances', autospec=True)
+@patch('pdchaosazure.vmss.actions.init_client', autospec=True)
 @patch.object(pdchaosazure.common.compute.command, 'prepare', autospec=True)
 @patch.object(pdchaosazure.common.compute.command, 'run', autospec=True)
-def test_stress_cpu(mocked_command_run, mocked_command_prepare, fetch_instance, fetch_vmss):
+def test_stress_cpu(mocked_command_run, mocked_command_prepare, mocked_client, mocked_instances, mocked_vmss):
     # arrange mocks
     mocked_command_prepare.return_value = 'RunShellScript', 'cpu_stress_test.sh'
 
@@ -84,18 +85,20 @@ def test_stress_cpu(mocked_command_run, mocked_command_prepare, fetch_instance, 
     scale_sets = [scale_set]
     instance = vmss_provider.provide_instance()
     instances = [instance]
-    fetch_vmss.return_value = scale_sets
-    fetch_instance.return_value = instances
+    mocked_vmss.return_value = scale_sets
+    mocked_instances.return_value = instances
 
     config = config_provider.provide_default_config()
     secrets = secrets_provider.provide_secrets_via_service_principal()
+
+    mocked_client.return_value = MockComputeManagementClient()
 
     # act
     stress_cpu(filter="where name=='some_random_instance'", duration=60, configuration=config, secrets=secrets)
 
     # assert
-    fetch_vmss.assert_called_with("where name=='some_random_instance'", config, secrets)
-    fetch_instance.assert_called_with(scale_set, None, config, secrets)
+    mocked_vmss.assert_called_with("where name=='some_random_instance'", config, secrets)
+    mocked_instances.assert_called_with(scale_set, None, mocked_client.return_value)
     mocked_command_prepare.assert_called_with(instance, 'cpu_stress_test')
     mocked_command_run.assert_called_with(
         scale_set['resourceGroup'], instance, 60,
@@ -112,9 +115,11 @@ def test_stress_cpu(mocked_command_run, mocked_command_prepare, fetch_instance, 
 
 @patch('pdchaosazure.vmss.actions.fetch_vmss', autospec=True)
 @patch('pdchaosazure.vmss.actions.fetch_instances', autospec=True)
+@patch('pdchaosazure.vmss.actions.init_client', autospec=True)
 @patch.object(pdchaosazure.common.compute.command, 'prepare', autospec=True)
 @patch.object(pdchaosazure.common.compute.command, 'run', autospec=True)
-def test_network_latency(mocked_command_run, mocked_command_prepare, fetch_instances, fetch_vmss):
+def test_network_latency(mocked_command_run, mocked_command_prepare, mocked_client,
+                         mocked_fetch_instances, mocked_fetch_vmss):
     # arrange mocks
     mocked_command_prepare.return_value = 'RunShellScript', 'network_latency.sh'
 
@@ -122,19 +127,21 @@ def test_network_latency(mocked_command_run, mocked_command_prepare, fetch_insta
     scale_sets = [scale_set]
     instance = vmss_provider.provide_instance()
     instances = [instance]
-    fetch_vmss.return_value = scale_sets
-    fetch_instances.return_value = instances
+    mocked_fetch_vmss.return_value = scale_sets
+    mocked_fetch_instances.return_value = instances
 
     config = config_provider.provide_default_config()
     secrets = secrets_provider.provide_secrets_via_service_principal()
+
+    mocked_client.return_value = MockComputeManagementClient()
 
     # act
     network_latency(filter="where name=='some_random_instance'", duration=60, delay=200, jitter=50,
                     configuration=config, secrets=secrets)
 
     # assert
-    fetch_vmss.assert_called_with("where name=='some_random_instance'", config, secrets)
-    fetch_instances.assert_called_with(scale_set, None, config, secrets)
+    mocked_fetch_vmss.assert_called_with("where name=='some_random_instance'", config, secrets)
+    mocked_fetch_instances.assert_called_with(scale_set, None, mocked_client.return_value)
     mocked_command_prepare.assert_called_with(instance, 'network_latency')
     mocked_command_run.assert_called_with(
         scale_set['resourceGroup'], instance, 60,
@@ -153,9 +160,10 @@ def test_network_latency(mocked_command_run, mocked_command_prepare, fetch_insta
 
 @patch('pdchaosazure.vmss.actions.fetch_vmss', autospec=True)
 @patch('pdchaosazure.vmss.actions.fetch_instances', autospec=True)
+@patch('pdchaosazure.vmss.actions.init_client', autospec=True)
 @patch.object(pdchaosazure.common.compute.command, 'prepare', autospec=True)
 @patch.object(pdchaosazure.common.compute.command, 'run', autospec=True)
-def test_burn_io(mocked_command_run, mocked_command_prepare, fetch_instances, fetch_vmss):
+def test_burn_io(mocked_command_run, mocked_command_prepare, mocked_client, fetch_instances, fetch_vmss):
     # arrange mocks
     mocked_command_prepare.return_value = 'RunShellScript', 'burn_io.sh'
 
@@ -169,12 +177,14 @@ def test_burn_io(mocked_command_run, mocked_command_prepare, fetch_instances, fe
     config = config_provider.provide_default_config()
     secrets = secrets_provider.provide_secrets_via_service_principal()
 
+    mocked_client.return_value = MockComputeManagementClient()
+
     # act
     burn_io(filter="where name=='some_random_instance'", duration=60, configuration=config, secrets=secrets)
 
     # assert
     fetch_vmss.assert_called_with("where name=='some_random_instance'", config, secrets)
-    fetch_instances.assert_called_with(scale_set, None, config, secrets)
+    fetch_instances.assert_called_with(scale_set, None, mocked_client.return_value)
     mocked_command_run.assert_called_with(
         scale_set['resourceGroup'], instance, 60,
         {
@@ -190,11 +200,12 @@ def test_burn_io(mocked_command_run, mocked_command_prepare, fetch_instances, fe
 
 @patch('pdchaosazure.vmss.actions.fetch_vmss', autospec=True)
 @patch('pdchaosazure.vmss.actions.fetch_instances', autospec=True)
+@patch('pdchaosazure.vmss.actions.init_client', autospec=True)
 @patch.object(pdchaosazure.common.compute.command, 'prepare_path', autospec=True)
 @patch.object(pdchaosazure.common.compute.command, 'prepare', autospec=True)
 @patch.object(pdchaosazure.common.compute.command, 'run', autospec=True)
-def test_fill_disk(mocked_command_run, mocked_command_prepare, mocked_command_prepare_path, fetch_instances,
-                   fetch_vmss):
+def test_fill_disk(mocked_command_run, mocked_command_prepare, mocked_command_prepare_path,
+                   mocked_client, fetch_instances, fetch_vmss):
     # arrange mocks
     mocked_command_prepare.return_value = 'RunShellScript', 'fill_disk.sh'
     mocked_command_prepare_path.return_value = '/root/burn/hard'
@@ -209,13 +220,15 @@ def test_fill_disk(mocked_command_run, mocked_command_prepare, mocked_command_pr
     config = config_provider.provide_default_config()
     secrets = secrets_provider.provide_secrets_via_service_principal()
 
+    mocked_client.return_value = MockComputeManagementClient()
+
     # act
     fill_disk(filter="where name=='some_random_instance'", duration=60, size=1000, path='/root/burn/hard',
               configuration=config, secrets=secrets)
 
     # assert
     fetch_vmss.assert_called_with("where name=='some_random_instance'", config, secrets)
-    fetch_instances.assert_called_with(scale_set, None, config, secrets)
+    fetch_instances.assert_called_with(scale_set, None, mocked_client.return_value)
     mocked_command_run.assert_called_with(
         scale_set['resourceGroup'], instance, 60,
         {

--- a/tests/vmss/test_vmss_fetcher.py
+++ b/tests/vmss/test_vmss_fetcher.py
@@ -38,7 +38,7 @@ def test_succesful_fetch_instances_without_instance_criteria(mocked_fetch_instan
 
     scale_set = vmss_provider.provide_scale_set()
 
-    result = fetch_instances(scale_set, None, None, None)
+    result = fetch_instances(scale_set, None, None)
 
     assert len(result) == 1
     assert result[0].get('name') == 'chaos-pool_0'
@@ -51,7 +51,7 @@ def test_empty_fetch_instances_without_instance_criteria(mocked_fetch_instances)
         mocked_fetch_instances.return_value = []
         scale_set = vmss_provider.provide_scale_set()
 
-        fetch_instances(scale_set, None, None, None)
+        fetch_instances(scale_set, None, None)
 
         assert "No VMSS instances" in str(x.value)
 
@@ -70,7 +70,7 @@ def test_succesful_fetch_instances_with_instance_criteria_for_instance0(mocked_f
     scale_set = vmss_provider.provide_scale_set()
 
     # fire
-    result = fetch_instances(scale_set, [{'instance_id': '0'}], None, None)
+    result = fetch_instances(scale_set, [{'instance_id': '0'}], None)
 
     # assert
     assert len(result) == 1
@@ -95,7 +95,7 @@ def test_succesful_fetch_instances_with_instance_criteria_for_instance0_instance
     scale_set = vmss_provider.provide_scale_set()
 
     # fire
-    result = fetch_instances(scale_set, [{'instance_id': '0'}, {'instance_id': '2'}], None, None)
+    result = fetch_instances(scale_set, [{'instance_id': '0'}, {'instance_id': '2'}], None)
 
     # assert
     assert len(result) == 2
@@ -123,7 +123,7 @@ def test_succesful_fetch_instances_with_instance_criteria_for_all_instances(mock
 
     # fire
     result = fetch_instances(
-        scale_set, [{'instance_id': '0'}, {'instance_id': '1'}, {'instance_id': '2'}], None, None)
+        scale_set, [{'instance_id': '0'}, {'instance_id': '1'}, {'instance_id': '2'}], None)
 
     # assert
     assert len(result) == 3
@@ -151,6 +151,6 @@ def test_empty_fetch_instances_with_instance_criteria(mocked_fetch_instances):
     # fire
     with pytest.raises(FailedActivity) as x:
         fetch_instances(
-            scale_set, [{'instance_id': '99'}, {'instance_id': '100'}, {'instance_id': '101'}], None, None)
+            scale_set, [{'instance_id': '99'}, {'instance_id': '100'}, {'instance_id': '101'}], None)
 
         assert "No VMSS instance" in x.value

--- a/tests/vmss/test_vmss_fetcher.py
+++ b/tests/vmss/test_vmss_fetcher.py
@@ -4,7 +4,7 @@ import pytest
 from chaoslib.exceptions import FailedActivity
 
 import pdchaosazure
-from pdchaosazure.vmss.actions import delete_vmss
+from pdchaosazure.vmss.actions import delete_instance
 from pdchaosazure.vmss.fetcher import fetch_vmss, fetch_instances
 from tests.data import vmss_provider
 
@@ -30,7 +30,7 @@ def test_empty_fetch_vmss(mocked_fetch_vmss):
         assert "No VMSS" in str(x.value)
 
 
-@patch.object(pdchaosazure.vmss.fetcher, '__fetch_vmss_instances', autospec=True)
+@patch.object(pdchaosazure.vmss.fetcher, 'fetch_all_vmss_instances', autospec=True)
 def test_succesful_fetch_instances_without_instance_criteria(mocked_fetch_instances):
     instance = vmss_provider.provide_instance()
     instances = [instance]
@@ -45,7 +45,7 @@ def test_succesful_fetch_instances_without_instance_criteria(mocked_fetch_instan
     assert result[0].get('instance_id') == '0'
 
 
-@patch.object(pdchaosazure.vmss.fetcher, '__fetch_vmss_instances', autospec=True)
+@patch.object(pdchaosazure.vmss.fetcher, 'fetch_all_vmss_instances', autospec=True)
 def test_empty_fetch_instances_without_instance_criteria(mocked_fetch_instances):
     with pytest.raises(FailedActivity) as x:
         mocked_fetch_instances.return_value = []
@@ -56,7 +56,7 @@ def test_empty_fetch_instances_without_instance_criteria(mocked_fetch_instances)
         assert "No VMSS instances" in str(x.value)
 
 
-@patch.object(pdchaosazure.vmss.fetcher, '__fetch_vmss_instances', autospec=True)
+@patch.object(pdchaosazure.vmss.fetcher, 'fetch_all_vmss_instances', autospec=True)
 def test_succesful_fetch_instances_with_instance_criteria_for_instance0(mocked_fetch_instances):
     # arrange
     instance_0 = vmss_provider.provide_instance()
@@ -78,7 +78,7 @@ def test_succesful_fetch_instances_with_instance_criteria_for_instance0(mocked_f
     assert result[0].get('instance_id') == '0'
 
 
-@patch.object(pdchaosazure.vmss.fetcher, '__fetch_vmss_instances', autospec=True)
+@patch.object(pdchaosazure.vmss.fetcher, 'fetch_all_vmss_instances', autospec=True)
 def test_succesful_fetch_instances_with_instance_criteria_for_instance0_instance_2(mocked_fetch_instances):
     # arrange
     instance_0 = vmss_provider.provide_instance()
@@ -105,7 +105,7 @@ def test_succesful_fetch_instances_with_instance_criteria_for_instance0_instance
     assert result[1].get('instance_id') == '2'
 
 
-@patch.object(pdchaosazure.vmss.fetcher, '__fetch_vmss_instances', autospec=True)
+@patch.object(pdchaosazure.vmss.fetcher, 'fetch_all_vmss_instances', autospec=True)
 def test_succesful_fetch_instances_with_instance_criteria_for_all_instances(mocked_fetch_instances):
     # arrange
     instance_0 = vmss_provider.provide_instance()
@@ -135,7 +135,7 @@ def test_succesful_fetch_instances_with_instance_criteria_for_all_instances(mock
     assert result[2].get('instance_id') == '2'
 
 
-@patch.object(pdchaosazure.vmss.fetcher, '__fetch_vmss_instances', autospec=True)
+@patch.object(pdchaosazure.vmss.fetcher, 'fetch_all_vmss_instances', autospec=True)
 def test_empty_fetch_instances_with_instance_criteria(mocked_fetch_instances):
     # arrange
     instance_0 = vmss_provider.provide_instance()

--- a/tests/vmss/test_vmss_probes.py
+++ b/tests/vmss/test_vmss_probes.py
@@ -1,17 +1,29 @@
 from unittest.mock import patch
 
 from pdchaosazure.vmss.probes import count_instances
-
-resource = {
-    'name': 'vmss_instance_0',
-    'resourceGroup': 'group'
-}
+from tests.data import vmss_provider
 
 
-@patch('pdchaosazure.vmss.probes.fetch_resources', autospec=True)
-def test_count_instances(fetch):
-    fetch.return_value = [resource]
+@patch('pdchaosazure.vmss.probes.fetch_all_vmss_instances', autospec=True)
+@patch('pdchaosazure.vmss.probes.fetch_vmss', autospec=True)
+def test_count_instances(mocked_fetch_vmss, mocked_all_vmss_instances):
+    mocked_fetch_vmss.return_value = [vmss_provider.provide_scale_set()]
+    mocked_all_vmss_instances.return_value = [vmss_provider.provide_instance()]
 
     count = count_instances(None, None)
 
     assert count == 1
+
+
+@patch('pdchaosazure.vmss.probes.fetch_all_vmss_instances', autospec=True)
+@patch('pdchaosazure.vmss.probes.fetch_vmss', autospec=True)
+def test_count_instances_for_two_sets(mocked_fetch_vmss, mocked_all_vmss_instances):
+    scale_sets = []
+    scale_sets.append(vmss_provider.provide_scale_set())
+    scale_sets.append(vmss_provider.provide_scale_set())
+    mocked_fetch_vmss.return_value = scale_sets
+    mocked_all_vmss_instances.return_value = [vmss_provider.provide_instance()]
+
+    count = count_instances(None, None)
+
+    assert count == 2

--- a/tests/vmss/test_vmss_probes.py
+++ b/tests/vmss/test_vmss_probes.py
@@ -2,13 +2,19 @@ from unittest.mock import patch
 
 from pdchaosazure.vmss.probes import count_instances
 from tests.data import vmss_provider
+from tests.vmss.mock_client import MockComputeManagementClient
 
 
 @patch('pdchaosazure.vmss.probes.fetch_all_vmss_instances', autospec=True)
 @patch('pdchaosazure.vmss.probes.fetch_vmss', autospec=True)
-def test_count_instances(mocked_fetch_vmss, mocked_all_vmss_instances):
+@patch('pdchaosazure.vmss.probes.init_client', autospec=True)
+def test_count_instances(mocked_client, mocked_fetch_vmss, mocked_all_vmss_instances):
+
+    # Arrange
     mocked_fetch_vmss.return_value = [vmss_provider.provide_scale_set()]
     mocked_all_vmss_instances.return_value = [vmss_provider.provide_instance()]
+
+    mocked_client.return_value = MockComputeManagementClient()
 
     count = count_instances(None, None)
 
@@ -17,12 +23,17 @@ def test_count_instances(mocked_fetch_vmss, mocked_all_vmss_instances):
 
 @patch('pdchaosazure.vmss.probes.fetch_all_vmss_instances', autospec=True)
 @patch('pdchaosazure.vmss.probes.fetch_vmss', autospec=True)
-def test_count_instances_for_two_sets(mocked_fetch_vmss, mocked_all_vmss_instances):
+@patch('pdchaosazure.vmss.probes.init_client', autospec=True)
+def test_count_instances_for_two_sets(mocked_client, mocked_fetch_vmss, mocked_all_vmss_instances):
+
+    # Arrange
     scale_sets = []
     scale_sets.append(vmss_provider.provide_scale_set())
     scale_sets.append(vmss_provider.provide_scale_set())
     mocked_fetch_vmss.return_value = scale_sets
     mocked_all_vmss_instances.return_value = [vmss_provider.provide_instance()]
+
+    mocked_client.return_value = MockComputeManagementClient()
 
     count = count_instances(None, None)
 

--- a/tests/webapp/test_webapp_actions.py
+++ b/tests/webapp/test_webapp_actions.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch, MagicMock
 
-from pdchaosazure.webapp.actions import stop_webapp, restart_webapp, \
-    start_webapp, delete_webapp
+from pdchaosazure.webapp.actions import stop_webapp, restart_webapp, delete_webapp
 
 CONFIG = {
     "azure": {
@@ -20,7 +19,7 @@ resource = {
     'resourceGroup': 'rg'}
 
 
-@patch('pdchaosazure.webapp.actions.fetch_webapps', autospec=True)
+@patch('pdchaosazure.webapp.actions.__fetch_webapps', autospec=True)
 @patch('pdchaosazure.webapp.actions.init_client', autospec=True)
 def test_stop_webapp(init, fetch):
     client = MagicMock()
@@ -36,7 +35,7 @@ def test_stop_webapp(init, fetch):
                                             resource['name'])
 
 
-@patch('pdchaosazure.webapp.actions.fetch_webapps', autospec=True)
+@patch('pdchaosazure.webapp.actions.__fetch_webapps', autospec=True)
 @patch('pdchaosazure.webapp.actions.init_client', autospec=True)
 def test_restart_webapp(init, fetch):
     client = MagicMock()
@@ -52,23 +51,7 @@ def test_restart_webapp(init, fetch):
                                             resource['name'])
 
 
-@patch('pdchaosazure.webapp.actions.fetch_webapps', autospec=True)
-@patch('pdchaosazure.webapp.actions.init_client', autospec=True)
-def test_start_webapp(init, fetch):
-    client = MagicMock()
-    init.return_value = client
-    resource_list = [resource]
-    fetch.return_value = resource_list
-
-    f = "where resourceGroup=~'rg'"
-    start_webapp(f, CONFIG, SECRETS)
-
-    fetch.assert_called_with(f, CONFIG, SECRETS)
-    client.web_apps.start.assert_called_with(resource['resourceGroup'],
-                                               resource['name'])
-
-
-@patch('pdchaosazure.webapp.actions.fetch_webapps', autospec=True)
+@patch('pdchaosazure.webapp.actions.__fetch_webapps', autospec=True)
 @patch('pdchaosazure.webapp.actions.init_client', autospec=True)
 def test_delete_webapp(init, fetch):
     client = MagicMock()


### PR DESCRIPTION
This commit enables blocking calls. The chaos-azure package will execute
commands in a synchronous manner. Users that want to execute the
commands asynchronously are able to do so by setting the background flag
to true.

Besides the blocking call feature this commit does the following:
* Move timeout to configuration and remove timeout from command runs
* Eased logging
* Enable webapp actions for more than one webapp
* Fixed VMSS probes

Closes: #4