### PR TITLE
Escape the backslashes in docstring - else it's not displayed correct…

### DIFF
--- a/pdchaosazure/machine/actions.py
+++ b/pdchaosazure/machine/actions.py
@@ -199,7 +199,7 @@ def fill_disk(filter: str = None,
 
     path : str, optional
         The absolute path to write the fill file into.
-        Defaults to ``C:\burn`` for Windows clients and ``/root/burn`` for Linux clients.
+        Defaults to ``C:\\burn`` for Windows clients and ``/root/burn`` for Linux clients.
     """
 
     logger.debug("Starting {}: configuration='{}', filter='{}', duration='{}', size='{}', path='{}'".format(
@@ -310,7 +310,7 @@ def burn_io(filter: str = None,
         How long the burn lasts. Defaults to 60 seconds.
 
     path : str, optional
-        The absolute path to write the stress file into. Defaults to ``C:\burn`` for Windows
+        The absolute path to write the stress file into. Defaults to ``C:\\burn`` for Windows
         clients and ``/root/burn`` for Linux clients.
     """
 

--- a/pdchaosazure/vmss/actions.py
+++ b/pdchaosazure/vmss/actions.py
@@ -304,7 +304,7 @@ def burn_io(filter_vmss: str = None,
         Duration of the stress test (in seconds) that generates high disk I/O operations. Defaults to 60 seconds.
 
     path : str, optional
-        The absolute path to write the stress file into. Defaults to ``C:\burn`` for Windows
+        The absolute path to write the stress file into. Defaults to ``C:\\burn`` for Windows
         clients and ``/root/burn`` for Linux clients.
     """
     operation_name = burn_io.__name__

--- a/pdchaosazure/vmss/actions.py
+++ b/pdchaosazure/vmss/actions.py
@@ -370,7 +370,7 @@ def fill_disk(filter_vmss: str = None,
 
     path : str, optional
         Location of the stressing file where it is generated. Defaults to ``/root/burn`` on Linux systems
-        and ``C:/burn`` on Windows machines.
+        and ``C:\\burn`` on Windows machines.
     """
     operation_name = fill_disk.__name__
 


### PR DESCRIPTION
…ly in MD